### PR TITLE
Most init() functions now auto-generated via template

### DIFF
--- a/.sourcery.yml
+++ b/.sourcery.yml
@@ -1,0 +1,5 @@
+sources:
+    - Sources
+templates:
+    - Templates
+output: Sources/Generated

--- a/README.md
+++ b/README.md
@@ -492,6 +492,20 @@ var body: some View {
 }
 ```
 
+## AutoInit Code Generation
+
+**This applies only to those forking and customizing the _Tabler_ code.**
+
+Many additional `init()` functions for each table variant are generated via the code template `Templates/AutoInit.stencil`.
+
+To regenerate, run the [Sourcery](https://github.com/krzysztofzablocki/Sourcery) command from the project directory.
+
+```
+$ sourcery
+```
+
+The generated code will be found in the `Sources/Generated` directory.
+
 ## See Also
 
 * [TablerDemo](https://github.com/openalloc/TablerDemo) - the demonstration app for this library, for value data sources

--- a/Sources/Generated/TablerGrid+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGrid+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerGrid {
+public extension TablerGrid {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -23,7 +23,7 @@ extension TablerGrid {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -42,7 +42,7 @@ extension TablerGrid {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -60,7 +60,7 @@ extension TablerGrid {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Results
@@ -77,7 +77,7 @@ extension TablerGrid {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Results
@@ -94,7 +94,7 @@ extension TablerGrid {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Results
@@ -111,7 +111,7 @@ extension TablerGrid {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Results
                   )

--- a/Sources/Generated/TablerGrid+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGrid+AutoInit.generated.swift
@@ -1,0 +1,129 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerGrid {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+}

--- a/Sources/Generated/TablerGrid+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGrid+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerGrid {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerGrid1+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGrid1+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerGrid1 {
+public extension TablerGrid1 {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -25,7 +25,7 @@ extension TablerGrid1 {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -46,7 +46,7 @@ extension TablerGrid1 {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -66,7 +66,7 @@ extension TablerGrid1 {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Results
@@ -85,7 +85,7 @@ extension TablerGrid1 {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Results
@@ -104,7 +104,7 @@ extension TablerGrid1 {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Results
@@ -123,7 +123,7 @@ extension TablerGrid1 {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Results
         , selected: Binding<Selected>

--- a/Sources/Generated/TablerGrid1+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGrid1+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerGrid1 {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerGrid1+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGrid1+AutoInit.generated.swift
@@ -1,0 +1,143 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerGrid1 {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+}

--- a/Sources/Generated/TablerGrid1B+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGrid1B+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerGrid1B {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerGrid1B+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGrid1B+AutoInit.generated.swift
@@ -1,0 +1,143 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerGrid1B {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+}

--- a/Sources/Generated/TablerGrid1B+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGrid1B+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerGrid1B {
+public extension TablerGrid1B {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -25,7 +25,7 @@ extension TablerGrid1B {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -46,7 +46,7 @@ extension TablerGrid1B {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -66,7 +66,7 @@ extension TablerGrid1B {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Binding<Results>
@@ -85,7 +85,7 @@ extension TablerGrid1B {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Binding<Results>
@@ -104,7 +104,7 @@ extension TablerGrid1B {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Binding<Results>
@@ -123,7 +123,7 @@ extension TablerGrid1B {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Binding<Results>
         , selected: Binding<Selected>

--- a/Sources/Generated/TablerGrid1C+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGrid1C+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerGrid1C {
+public extension TablerGrid1C {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -25,7 +25,7 @@ extension TablerGrid1C {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -46,7 +46,7 @@ extension TablerGrid1C {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -66,7 +66,7 @@ extension TablerGrid1C {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Results
@@ -85,7 +85,7 @@ extension TablerGrid1C {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Results
@@ -104,7 +104,7 @@ extension TablerGrid1C {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Results
@@ -123,7 +123,7 @@ extension TablerGrid1C {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Results
         , selected: Binding<Selected>

--- a/Sources/Generated/TablerGrid1C+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGrid1C+AutoInit.generated.swift
@@ -1,0 +1,143 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerGrid1C {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+}

--- a/Sources/Generated/TablerGrid1C+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGrid1C+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerGrid1C {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerGridB+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGridB+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerGridB {
+public extension TablerGridB {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -23,7 +23,7 @@ extension TablerGridB {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -42,7 +42,7 @@ extension TablerGridB {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -60,7 +60,7 @@ extension TablerGridB {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Binding<Results>
@@ -77,7 +77,7 @@ extension TablerGridB {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Binding<Results>
@@ -94,7 +94,7 @@ extension TablerGridB {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Binding<Results>
@@ -111,7 +111,7 @@ extension TablerGridB {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Binding<Results>
                   )

--- a/Sources/Generated/TablerGridB+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGridB+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerGridB {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerGridB+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGridB+AutoInit.generated.swift
@@ -1,0 +1,129 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerGridB {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Binding<Results>
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Binding<Results>
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Binding<Results>
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Binding<Results>
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+}

--- a/Sources/Generated/TablerGridC+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGridC+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerGridC {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerGridC+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGridC+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerGridC {
+public extension TablerGridC {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -23,7 +23,7 @@ extension TablerGridC {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -42,7 +42,7 @@ extension TablerGridC {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -60,7 +60,7 @@ extension TablerGridC {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Results
@@ -77,7 +77,7 @@ extension TablerGridC {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Results
@@ -94,7 +94,7 @@ extension TablerGridC {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Results
@@ -111,7 +111,7 @@ extension TablerGridC {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Results
                   )

--- a/Sources/Generated/TablerGridC+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGridC+AutoInit.generated.swift
@@ -1,0 +1,129 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerGridC {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+}

--- a/Sources/Generated/TablerGridM+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGridM+AutoInit.generated.swift
@@ -1,0 +1,143 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerGridM {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+}

--- a/Sources/Generated/TablerGridM+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGridM+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerGridM {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerGridM+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGridM+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerGridM {
+public extension TablerGridM {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -25,7 +25,7 @@ extension TablerGridM {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -46,7 +46,7 @@ extension TablerGridM {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -66,7 +66,7 @@ extension TablerGridM {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Results
@@ -85,7 +85,7 @@ extension TablerGridM {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Results
@@ -104,7 +104,7 @@ extension TablerGridM {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Results
@@ -123,7 +123,7 @@ extension TablerGridM {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Results
         , selected: Binding<Selected>

--- a/Sources/Generated/TablerGridMB+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGridMB+AutoInit.generated.swift
@@ -1,0 +1,143 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerGridMB {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+}

--- a/Sources/Generated/TablerGridMB+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGridMB+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerGridMB {
+public extension TablerGridMB {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -25,7 +25,7 @@ extension TablerGridMB {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -46,7 +46,7 @@ extension TablerGridMB {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -66,7 +66,7 @@ extension TablerGridMB {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Binding<Results>
@@ -85,7 +85,7 @@ extension TablerGridMB {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Binding<Results>
@@ -104,7 +104,7 @@ extension TablerGridMB {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Binding<Results>
@@ -123,7 +123,7 @@ extension TablerGridMB {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Binding<Results>
         , selected: Binding<Selected>

--- a/Sources/Generated/TablerGridMB+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGridMB+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerGridMB {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerGridMC+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGridMC+AutoInit.generated.swift
@@ -1,0 +1,143 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerGridMC {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+}

--- a/Sources/Generated/TablerGridMC+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGridMC+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerGridMC {
+public extension TablerGridMC {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -25,7 +25,7 @@ extension TablerGridMC {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -46,7 +46,7 @@ extension TablerGridMC {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -66,7 +66,7 @@ extension TablerGridMC {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Results
@@ -85,7 +85,7 @@ extension TablerGridMC {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Results
@@ -104,7 +104,7 @@ extension TablerGridMC {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Results
@@ -123,7 +123,7 @@ extension TablerGridMC {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Results
         , selected: Binding<Selected>

--- a/Sources/Generated/TablerGridMC+AutoInit.generated.swift
+++ b/Sources/Generated/TablerGridMC+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerGridMC {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerList+AutoInit.generated.swift
+++ b/Sources/Generated/TablerList+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerList {
+public extension TablerList {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -23,7 +23,7 @@ extension TablerList {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -42,7 +42,7 @@ extension TablerList {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -60,7 +60,7 @@ extension TablerList {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Results
@@ -77,7 +77,7 @@ extension TablerList {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Results
@@ -94,7 +94,7 @@ extension TablerList {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Results
@@ -111,7 +111,7 @@ extension TablerList {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Results
                   )

--- a/Sources/Generated/TablerList+AutoInit.generated.swift
+++ b/Sources/Generated/TablerList+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerList {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerList+AutoInit.generated.swift
+++ b/Sources/Generated/TablerList+AutoInit.generated.swift
@@ -1,0 +1,129 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerList {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+}

--- a/Sources/Generated/TablerList1+AutoInit.generated.swift
+++ b/Sources/Generated/TablerList1+AutoInit.generated.swift
@@ -1,0 +1,143 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerList1 {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+}

--- a/Sources/Generated/TablerList1+AutoInit.generated.swift
+++ b/Sources/Generated/TablerList1+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerList1 {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerList1+AutoInit.generated.swift
+++ b/Sources/Generated/TablerList1+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerList1 {
+public extension TablerList1 {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -25,7 +25,7 @@ extension TablerList1 {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -46,7 +46,7 @@ extension TablerList1 {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -66,7 +66,7 @@ extension TablerList1 {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Results
@@ -85,7 +85,7 @@ extension TablerList1 {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Results
@@ -104,7 +104,7 @@ extension TablerList1 {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Results
@@ -123,7 +123,7 @@ extension TablerList1 {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Results
         , selected: Binding<Selected>

--- a/Sources/Generated/TablerList1B+AutoInit.generated.swift
+++ b/Sources/Generated/TablerList1B+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerList1B {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerList1B+AutoInit.generated.swift
+++ b/Sources/Generated/TablerList1B+AutoInit.generated.swift
@@ -1,0 +1,143 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerList1B {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+}

--- a/Sources/Generated/TablerList1B+AutoInit.generated.swift
+++ b/Sources/Generated/TablerList1B+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerList1B {
+public extension TablerList1B {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -25,7 +25,7 @@ extension TablerList1B {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -46,7 +46,7 @@ extension TablerList1B {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -66,7 +66,7 @@ extension TablerList1B {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Binding<Results>
@@ -85,7 +85,7 @@ extension TablerList1B {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Binding<Results>
@@ -104,7 +104,7 @@ extension TablerList1B {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Binding<Results>
@@ -123,7 +123,7 @@ extension TablerList1B {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Binding<Results>
         , selected: Binding<Selected>

--- a/Sources/Generated/TablerList1C+AutoInit.generated.swift
+++ b/Sources/Generated/TablerList1C+AutoInit.generated.swift
@@ -1,0 +1,143 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerList1C {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+}

--- a/Sources/Generated/TablerList1C+AutoInit.generated.swift
+++ b/Sources/Generated/TablerList1C+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerList1C {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerList1C+AutoInit.generated.swift
+++ b/Sources/Generated/TablerList1C+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerList1C {
+public extension TablerList1C {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -25,7 +25,7 @@ extension TablerList1C {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -46,7 +46,7 @@ extension TablerList1C {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -66,7 +66,7 @@ extension TablerList1C {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Results
@@ -85,7 +85,7 @@ extension TablerList1C {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Results
@@ -104,7 +104,7 @@ extension TablerList1C {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Results
@@ -123,7 +123,7 @@ extension TablerList1C {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Results
         , selected: Binding<Selected>

--- a/Sources/Generated/TablerListB+AutoInit.generated.swift
+++ b/Sources/Generated/TablerListB+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerListB {
+public extension TablerListB {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -23,7 +23,7 @@ extension TablerListB {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -42,7 +42,7 @@ extension TablerListB {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -60,7 +60,7 @@ extension TablerListB {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Binding<Results>
@@ -77,7 +77,7 @@ extension TablerListB {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Binding<Results>
@@ -94,7 +94,7 @@ extension TablerListB {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Binding<Results>
@@ -111,7 +111,7 @@ extension TablerListB {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Binding<Results>
                   )

--- a/Sources/Generated/TablerListB+AutoInit.generated.swift
+++ b/Sources/Generated/TablerListB+AutoInit.generated.swift
@@ -1,0 +1,129 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerListB {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Binding<Results>
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Binding<Results>
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Binding<Results>
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Binding<Results>
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+}

--- a/Sources/Generated/TablerListB+AutoInit.generated.swift
+++ b/Sources/Generated/TablerListB+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerListB {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerListC+AutoInit.generated.swift
+++ b/Sources/Generated/TablerListC+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerListC {
+public extension TablerListC {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -23,7 +23,7 @@ extension TablerListC {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -42,7 +42,7 @@ extension TablerListC {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -60,7 +60,7 @@ extension TablerListC {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Results
@@ -77,7 +77,7 @@ extension TablerListC {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Results
@@ -94,7 +94,7 @@ extension TablerListC {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Results
@@ -111,7 +111,7 @@ extension TablerListC {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Results
                   )

--- a/Sources/Generated/TablerListC+AutoInit.generated.swift
+++ b/Sources/Generated/TablerListC+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerListC {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerListC+AutoInit.generated.swift
+++ b/Sources/Generated/TablerListC+AutoInit.generated.swift
@@ -1,0 +1,129 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerListC {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+}

--- a/Sources/Generated/TablerListM+AutoInit.generated.swift
+++ b/Sources/Generated/TablerListM+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerListM {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerListM+AutoInit.generated.swift
+++ b/Sources/Generated/TablerListM+AutoInit.generated.swift
@@ -1,0 +1,143 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerListM {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+}

--- a/Sources/Generated/TablerListM+AutoInit.generated.swift
+++ b/Sources/Generated/TablerListM+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerListM {
+public extension TablerListM {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -25,7 +25,7 @@ extension TablerListM {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -46,7 +46,7 @@ extension TablerListM {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -66,7 +66,7 @@ extension TablerListM {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Results
@@ -85,7 +85,7 @@ extension TablerListM {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Results
@@ -104,7 +104,7 @@ extension TablerListM {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Results
@@ -123,7 +123,7 @@ extension TablerListM {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Results
         , selected: Binding<Selected>

--- a/Sources/Generated/TablerListMB+AutoInit.generated.swift
+++ b/Sources/Generated/TablerListMB+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerListMB {
+public extension TablerListMB {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -25,7 +25,7 @@ extension TablerListMB {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -46,7 +46,7 @@ extension TablerListMB {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -66,7 +66,7 @@ extension TablerListMB {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Binding<Results>
@@ -85,7 +85,7 @@ extension TablerListMB {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Binding<Results>
@@ -104,7 +104,7 @@ extension TablerListMB {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Binding<Results>
@@ -123,7 +123,7 @@ extension TablerListMB {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Binding<Results>
         , selected: Binding<Selected>

--- a/Sources/Generated/TablerListMB+AutoInit.generated.swift
+++ b/Sources/Generated/TablerListMB+AutoInit.generated.swift
@@ -1,0 +1,143 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerListMB {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+}

--- a/Sources/Generated/TablerListMB+AutoInit.generated.swift
+++ b/Sources/Generated/TablerListMB+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerListMB {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerListMC+AutoInit.generated.swift
+++ b/Sources/Generated/TablerListMC+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerListMC {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerListMC+AutoInit.generated.swift
+++ b/Sources/Generated/TablerListMC+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerListMC {
+public extension TablerListMC {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -25,7 +25,7 @@ extension TablerListMC {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -46,7 +46,7 @@ extension TablerListMC {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -66,7 +66,7 @@ extension TablerListMC {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Results
@@ -85,7 +85,7 @@ extension TablerListMC {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Results
@@ -104,7 +104,7 @@ extension TablerListMC {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Results
@@ -123,7 +123,7 @@ extension TablerListMC {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Results
         , selected: Binding<Selected>

--- a/Sources/Generated/TablerListMC+AutoInit.generated.swift
+++ b/Sources/Generated/TablerListMC+AutoInit.generated.swift
@@ -1,0 +1,143 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerListMC {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+}

--- a/Sources/Generated/TablerStack+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStack+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerStack {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerStack+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStack+AutoInit.generated.swift
@@ -1,0 +1,129 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerStack {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+}

--- a/Sources/Generated/TablerStack+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStack+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerStack {
+public extension TablerStack {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -23,7 +23,7 @@ extension TablerStack {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -42,7 +42,7 @@ extension TablerStack {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -60,7 +60,7 @@ extension TablerStack {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Results
@@ -77,7 +77,7 @@ extension TablerStack {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Results
@@ -94,7 +94,7 @@ extension TablerStack {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Results
@@ -111,7 +111,7 @@ extension TablerStack {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Results
                   )

--- a/Sources/Generated/TablerStack1+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStack1+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerStack1 {
+public extension TablerStack1 {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -25,7 +25,7 @@ extension TablerStack1 {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -46,7 +46,7 @@ extension TablerStack1 {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -66,7 +66,7 @@ extension TablerStack1 {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Results
@@ -85,7 +85,7 @@ extension TablerStack1 {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Results
@@ -104,7 +104,7 @@ extension TablerStack1 {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Results
@@ -123,7 +123,7 @@ extension TablerStack1 {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Results
         , selected: Binding<Selected>

--- a/Sources/Generated/TablerStack1+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStack1+AutoInit.generated.swift
@@ -1,0 +1,143 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerStack1 {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+}

--- a/Sources/Generated/TablerStack1+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStack1+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerStack1 {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerStack1B+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStack1B+AutoInit.generated.swift
@@ -1,0 +1,143 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerStack1B {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+}

--- a/Sources/Generated/TablerStack1B+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStack1B+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerStack1B {
+public extension TablerStack1B {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -25,7 +25,7 @@ extension TablerStack1B {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -46,7 +46,7 @@ extension TablerStack1B {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -66,7 +66,7 @@ extension TablerStack1B {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Binding<Results>
@@ -85,7 +85,7 @@ extension TablerStack1B {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Binding<Results>
@@ -104,7 +104,7 @@ extension TablerStack1B {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Binding<Results>
@@ -123,7 +123,7 @@ extension TablerStack1B {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Binding<Results>
         , selected: Binding<Selected>

--- a/Sources/Generated/TablerStack1B+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStack1B+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerStack1B {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerStack1C+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStack1C+AutoInit.generated.swift
@@ -1,0 +1,143 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerStack1C {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+}

--- a/Sources/Generated/TablerStack1C+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStack1C+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerStack1C {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerStack1C+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStack1C+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerStack1C {
+public extension TablerStack1C {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -25,7 +25,7 @@ extension TablerStack1C {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -46,7 +46,7 @@ extension TablerStack1C {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -66,7 +66,7 @@ extension TablerStack1C {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Results
@@ -85,7 +85,7 @@ extension TablerStack1C {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Results
@@ -104,7 +104,7 @@ extension TablerStack1C {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Results
@@ -123,7 +123,7 @@ extension TablerStack1C {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Results
         , selected: Binding<Selected>

--- a/Sources/Generated/TablerStackB+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStackB+AutoInit.generated.swift
@@ -1,0 +1,129 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerStackB {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Binding<Results>
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Binding<Results>
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Binding<Results>
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Binding<Results>
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+}

--- a/Sources/Generated/TablerStackB+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStackB+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerStackB {
+public extension TablerStackB {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -23,7 +23,7 @@ extension TablerStackB {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -42,7 +42,7 @@ extension TablerStackB {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -60,7 +60,7 @@ extension TablerStackB {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Binding<Results>
@@ -77,7 +77,7 @@ extension TablerStackB {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Binding<Results>
@@ -94,7 +94,7 @@ extension TablerStackB {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Binding<Results>
@@ -111,7 +111,7 @@ extension TablerStackB {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Binding<Results>
                   )

--- a/Sources/Generated/TablerStackB+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStackB+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerStackB {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerStackC+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStackC+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerStackC {
+public extension TablerStackC {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -23,7 +23,7 @@ extension TablerStackC {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -42,7 +42,7 @@ extension TablerStackC {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -60,7 +60,7 @@ extension TablerStackC {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Results
@@ -77,7 +77,7 @@ extension TablerStackC {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Results
@@ -94,7 +94,7 @@ extension TablerStackC {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Results
@@ -111,7 +111,7 @@ extension TablerStackC {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Results
                   )

--- a/Sources/Generated/TablerStackC+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStackC+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerStackC {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerStackC+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStackC+AutoInit.generated.swift
@@ -1,0 +1,129 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerStackC {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  )
+    }
+}

--- a/Sources/Generated/TablerStackM+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStackM+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerStackM {
+public extension TablerStackM {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -25,7 +25,7 @@ extension TablerStackM {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -46,7 +46,7 @@ extension TablerStackM {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -66,7 +66,7 @@ extension TablerStackM {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Results
@@ -85,7 +85,7 @@ extension TablerStackM {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Results
@@ -104,7 +104,7 @@ extension TablerStackM {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Results
@@ -123,7 +123,7 @@ extension TablerStackM {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Results
         , selected: Binding<Selected>

--- a/Sources/Generated/TablerStackM+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStackM+AutoInit.generated.swift
@@ -1,0 +1,143 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerStackM {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+}

--- a/Sources/Generated/TablerStackM+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStackM+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerStackM {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerStackMB+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStackMB+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerStackMB {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerStackMB+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStackMB+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerStackMB {
+public extension TablerStackMB {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -25,7 +25,7 @@ extension TablerStackMB {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -46,7 +46,7 @@ extension TablerStackMB {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -66,7 +66,7 @@ extension TablerStackMB {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Binding<Results>
@@ -85,7 +85,7 @@ extension TablerStackMB {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Binding<Results>
@@ -104,7 +104,7 @@ extension TablerStackMB {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Binding<Results>
@@ -123,7 +123,7 @@ extension TablerStackMB {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Binding<Results>
         , selected: Binding<Selected>

--- a/Sources/Generated/TablerStackMB+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStackMB+AutoInit.generated.swift
@@ -1,0 +1,143 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerStackMB {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Binding<Results>
+        , selected: Binding<Selected>
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+}

--- a/Sources/Generated/TablerStackMC+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStackMC+AutoInit.generated.swift
@@ -3,9 +3,9 @@
 
 import SwiftUI
 
-extension TablerStackMC {
+public extension TablerStackMC {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -25,7 +25,7 @@ extension TablerStackMC {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -46,7 +46,7 @@ extension TablerStackMC {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -66,7 +66,7 @@ extension TablerStackMC {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         , results: Results
@@ -85,7 +85,7 @@ extension TablerStackMC {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         , results: Results
@@ -104,7 +104,7 @@ extension TablerStackMC {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         , results: Results
@@ -123,7 +123,7 @@ extension TablerStackMC {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         , results: Results
         , selected: Binding<Selected>

--- a/Sources/Generated/TablerStackMC+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStackMC+AutoInit.generated.swift
@@ -4,7 +4,7 @@
 import SwiftUI
 
 extension TablerStackMC {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Sources/Generated/TablerStackMC+AutoInit.generated.swift
+++ b/Sources/Generated/TablerStackMC+AutoInit.generated.swift
@@ -1,0 +1,143 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import SwiftUI
+
+extension TablerStackMC {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        , results: Results
+        , selected: Binding<Selected>
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  , selected: selected
+                  )
+    }
+}

--- a/Sources/Grid/TablerGrid.swift
+++ b/Sources/Grid/TablerGrid.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit
 /// Grid-based table
 public struct TablerGrid<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable,
@@ -76,114 +77,5 @@ public struct TablerGrid<Element, Header, Row, RowBack, RowOver, Results>: View
                     .overlay(rowOverlay(element))
             }
         }
-    }
-}
-
-public extension TablerGrid {
-    // omitting Header
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-
-    // omitting Overlay
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-
-    // omitting Background
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-
-    // omitting Header AND Background
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-
-    // omitting Background AND Overlay
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Results)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         results: Results)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
     }
 }

--- a/Sources/Grid/TablerGrid1.swift
+++ b/Sources/Grid/TablerGrid1.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit, selectBinding
 /// Grid-based table, with support for single-select
 public struct TablerGrid1<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable,
@@ -82,128 +83,5 @@ public struct TablerGrid1<Element, Header, Row, RowBack, RowOver, Results>: View
                     .overlay(rowOverlay(element))
             }
         }
-    }
-}
-
-public extension TablerGrid1 {
-    // omitting Header
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Overlay
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Background
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header AND Background
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Background AND Overlay
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
     }
 }

--- a/Sources/Grid/TablerGrid1B.swift
+++ b/Sources/Grid/TablerGrid1B.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit, selectBinding, resultsBinding
 /// Grid-based table, with support for single-select and bound value types
 public struct TablerGrid1B<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable,
@@ -83,128 +84,5 @@ public struct TablerGrid1B<Element, Header, Row, RowBack, RowOver, Results>: Vie
                     .overlay(rowOverlay(element))
             }
         }
-    }
-}
-
-public extension TablerGrid1B {
-    // omitting Header
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Overlay
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Background
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Header AND Background
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Background AND Overlay
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
     }
 }

--- a/Sources/Grid/TablerGrid1C.swift
+++ b/Sources/Grid/TablerGrid1C.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit, selectBinding
 /// Grid-based table, with support for reference types
 public struct TablerGrid1C<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable & ObservableObject,
@@ -85,128 +86,5 @@ public struct TablerGrid1C<Element, Header, Row, RowBack, RowOver, Results>: Vie
                 }
             }
         }
-    }
-}
-
-public extension TablerGrid1C {
-    // omitting Header
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Overlay
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Background
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Header AND Background
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Background AND Overlay
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
     }
 }

--- a/Sources/Grid/TablerGridB.swift
+++ b/Sources/Grid/TablerGridB.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit, resultsBinding
 /// Grid-based table, with support for bound value types
 public struct TablerGridB<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable,
@@ -78,114 +79,5 @@ public struct TablerGridB<Element, Header, Row, RowBack, RowOver, Results>: View
                     .overlay(rowOverlay(element))
             }
         }
-    }
-}
-
-public extension TablerGridB {
-    // omitting Header
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-
-    // omitting Overlay
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Binding<Results>)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-
-    // omitting Background
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Binding<Results>)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-    
-    // omitting Header AND Background
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-    
-    // omitting Background AND Overlay
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Binding<Results>)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         results: Binding<Results>)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
     }
 }

--- a/Sources/Grid/TablerGridC.swift
+++ b/Sources/Grid/TablerGridC.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit
 /// Grid-based table, with support for reference types
 public struct TablerGridC<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable & ObservableObject,
@@ -80,114 +81,5 @@ public struct TablerGridC<Element, Header, Row, RowBack, RowOver, Results>: View
                 }
             }
         }
-    }
-}
-
-public extension TablerGridC {
-    // omitting Header
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-
-    // omitting Overlay
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-
-    // omitting Background
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-    
-    // omitting Header AND Background
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-    
-    // omitting Background AND Overlay
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Results)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         results: Results)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
     }
 }

--- a/Sources/Grid/TablerGridConfig.swift
+++ b/Sources/Grid/TablerGridConfig.swift
@@ -40,7 +40,7 @@ where Element: Identifiable
     public let alignment: HorizontalAlignment
     public let itemPadding: EdgeInsets
     
-    public init(gridItems: [GridItem],
+    public init(gridItems: [GridItem] = [],
                 alignment: HorizontalAlignment = TablerGridConfigDefaults.alignment,
                 itemPadding: EdgeInsets = TablerGridConfigDefaults.itemPadding,
                 headerSpacing: CGFloat = TablerGridConfigDefaults.headerSpacing,

--- a/Sources/Grid/TablerGridM.swift
+++ b/Sources/Grid/TablerGridM.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit, selectBinding
 /// Grid-based table, with support for multi-select
 public struct TablerGridM<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable,
@@ -82,128 +83,5 @@ public struct TablerGridM<Element, Header, Row, RowBack, RowOver, Results>: View
                     .overlay(rowOverlay(element))
             }
         }
-    }
-}
-
-public extension TablerGridM {
-    // omitting Header
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Overlay
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Background
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header AND Background
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Background AND Overlay
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
     }
 }

--- a/Sources/Grid/TablerGridMB.swift
+++ b/Sources/Grid/TablerGridMB.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit, selectBinding, resultsBinding
 /// Grid-based table, with support for multi-select and bound value types
 public struct TablerGridMB<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable,
@@ -83,128 +84,5 @@ public struct TablerGridMB<Element, Header, Row, RowBack, RowOver, Results>: Vie
                     .overlay(rowOverlay(element))
             }
         }
-    }
-}
-
-public extension TablerGridMB {
-    // omitting Header
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Overlay
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Background
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Header AND Background
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Background AND Overlay
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
     }
 }

--- a/Sources/Grid/TablerGridMC.swift
+++ b/Sources/Grid/TablerGridMC.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit, selectBinding
 /// Grid-based table, with support for multi-select and reference types
 public struct TablerGridMC<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable & ObservableObject,
@@ -85,128 +86,5 @@ public struct TablerGridMC<Element, Header, Row, RowBack, RowOver, Results>: Vie
                 }
             }
         }
-    }
-}
-
-public extension TablerGridMC {
-    // omitting Header
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Overlay
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Background
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Header AND Background
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Background AND Overlay
-    init(_ config: Config,
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config,
-         @ViewBuilder row: @escaping RowContent,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
     }
 }

--- a/Sources/List/TablerList.swift
+++ b/Sources/List/TablerList.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit
 /// List-based table
 public struct TablerList<Element, Header, Row, RowBack, RowOver, Results>: View
 where Element: Identifiable,
@@ -78,114 +79,5 @@ where Element: Identifiable,
             }
             .onMove(perform: config.onMove)
         }
-    }
-}
-
-public extension TablerList {
-    // omitting Header
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-
-    // omitting Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-
-    // omitting Background
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-    
-    // omitting Header AND Background
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-    
-    // omitting Background AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Results)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         results: Results)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
     }
 }

--- a/Sources/List/TablerList1.swift
+++ b/Sources/List/TablerList1.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit, selectBinding
 /// List-based table, with support for single-select
 public struct TablerList1<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable,
@@ -83,128 +84,5 @@ public struct TablerList1<Element, Header, Row, RowBack, RowOver, Results>: View
             }
             .onMove(perform: config.onMove)
         }
-    }
-}
-
-public extension TablerList1 {
-    // omitting Header
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Background
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Header AND Background
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Background AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
     }
 }

--- a/Sources/List/TablerList1B.swift
+++ b/Sources/List/TablerList1B.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit, selectBinding, resultsBinding
 /// List-based table, with support for single-select and bound value types
 public struct TablerList1B<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable,
@@ -98,128 +99,5 @@ public struct TablerList1B<Element, Header, Row, RowBack, RowOver, Results>: Vie
                                  element: element.wrappedValue))
             .listRowBackground(rowBackground(element.wrappedValue))
             .overlay(rowOverlay(element.wrappedValue))
-    }
-}
-
-public extension TablerList1B {
-    // omitting Header
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Background
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Header AND Background
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Background AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
     }
 }

--- a/Sources/List/TablerList1C.swift
+++ b/Sources/List/TablerList1C.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit, selectBinding
 /// List-based table, with support for single-select and reference types
 public struct TablerList1C<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable & ObservableObject,
@@ -86,128 +87,5 @@ public struct TablerList1C<Element, Header, Row, RowBack, RowOver, Results>: Vie
             }
             .onMove(perform: config.onMove)
         }
-    }
-}
-
-public extension TablerList1C {
-    // omitting Header
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Background
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Header AND Background
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Background AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
     }
 }

--- a/Sources/List/TablerListB.swift
+++ b/Sources/List/TablerListB.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit, resultsBinding
 /// List-based table, with support for bound value types
 public struct TablerListB<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable,
@@ -93,114 +94,5 @@ public struct TablerListB<Element, Header, Row, RowBack, RowOver, Results>: View
                                  element: element.wrappedValue))
             .listRowBackground(rowBackground(element.wrappedValue))
             .overlay(rowOverlay(element.wrappedValue))
-    }
-}
-
-public extension TablerListB {
-    // omitting Header
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-
-    // omitting Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Binding<Results>)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-
-    // omitting Background
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Binding<Results>)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-    
-    // omitting Header AND Background
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-    
-    // omitting Background AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Binding<Results>)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         results: Binding<Results>)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
     }
 }

--- a/Sources/List/TablerListC.swift
+++ b/Sources/List/TablerListC.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit
 /// List-based table, with support for reference types
 public struct TablerListC<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable & ObservableObject,
@@ -81,114 +82,5 @@ public struct TablerListC<Element, Header, Row, RowBack, RowOver, Results>: View
             }
             .onMove(perform: config.onMove)
         }
-    }
-}
-
-public extension TablerListC {
-    // omitting Header
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-
-    // omitting Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-
-    // omitting Background
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-    
-    // omitting Header AND Background
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-    
-    // omitting Background AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Results)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         results: Results)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
     }
 }

--- a/Sources/List/TablerListM.swift
+++ b/Sources/List/TablerListM.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit, selectBinding
 /// List-based table, with support for multi-select
 public struct TablerListM<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable,
@@ -83,128 +84,5 @@ public struct TablerListM<Element, Header, Row, RowBack, RowOver, Results>: View
             }
             .onMove(perform: config.onMove)
         }
-    }
-}
-
-public extension TablerListM {
-    // omitting Header
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Background
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Header AND Background
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Background AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
     }
 }

--- a/Sources/List/TablerListMB.swift
+++ b/Sources/List/TablerListMB.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit, selectBinding, resultsBinding
 /// List-based table, with support for multi-select and bound value types
 public struct TablerListMB<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable,
@@ -98,128 +99,5 @@ public struct TablerListMB<Element, Header, Row, RowBack, RowOver, Results>: Vie
                                  element: element.wrappedValue))
             .listRowBackground(rowBackground(element.wrappedValue))
             .overlay(rowOverlay(element.wrappedValue))
-    }
-}
-
-public extension TablerListMB {
-    // omitting Header
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Background
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Header AND Background
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Background AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
     }
 }

--- a/Sources/List/TablerListMC.swift
+++ b/Sources/List/TablerListMC.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit, selectBinding
 /// List-based table, with support for multi-select and reference types
 public struct TablerListMC<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable & ObservableObject,
@@ -86,128 +87,5 @@ public struct TablerListMC<Element, Header, Row, RowBack, RowOver, Results>: Vie
             }
             .onMove(perform: config.onMove)
         }
-    }
-}
-
-public extension TablerListMC {
-    // omitting Header
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Background
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Header AND Background
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Background AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
     }
 }

--- a/Sources/Stack/TablerStack.swift
+++ b/Sources/Stack/TablerStack.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit
 /// Stack-based table
 public struct TablerStack<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable,
@@ -75,114 +76,5 @@ public struct TablerStack<Element, Header, Row, RowBack, RowOver, Results>: View
                     .overlay(rowOverlay(element))
             }
         }
-    }
-}
-
-public extension TablerStack {
-    // omitting Header
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-
-    // omitting Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-
-    // omitting Background
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-
-    // omitting Header AND Background
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-
-    // omitting Background AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Results)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         results: Results)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
     }
 }

--- a/Sources/Stack/TablerStack1.swift
+++ b/Sources/Stack/TablerStack1.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit, selectBinding
 /// Stack-based table, with support for single-select
 public struct TablerStack1<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable,
@@ -82,128 +83,5 @@ public struct TablerStack1<Element, Header, Row, RowBack, RowOver, Results>: Vie
                     .overlay(rowOverlay(element))
             }
         }
-    }
-}
-
-public extension TablerStack1 {
-    // omitting Header
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Background
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header AND Background
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Background AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
     }
 }

--- a/Sources/Stack/TablerStack1B.swift
+++ b/Sources/Stack/TablerStack1B.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit, selectBinding, resultsBinding
 /// Stack-based table, with support for single-select and bound value types
 public struct TablerStack1B<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable,
@@ -96,128 +97,5 @@ public struct TablerStack1B<Element, Header, Row, RowBack, RowOver, Results>: Vi
                                    selected: $selected))
             .background(rowBackground(element.wrappedValue))
             .overlay(rowOverlay(element.wrappedValue))
-    }
-}
-
-public extension TablerStack1B {
-    // omitting Header
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Background
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Header AND Background
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Background AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
     }
 }

--- a/Sources/Stack/TablerStack1C.swift
+++ b/Sources/Stack/TablerStack1C.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit, selectBinding
 /// Stack-based table, with support for reference types
 public struct TablerStack1C<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable & ObservableObject,
@@ -85,128 +86,5 @@ public struct TablerStack1C<Element, Header, Row, RowBack, RowOver, Results>: Vi
                 }
             }
         }
-    }
-}
-
-public extension TablerStack1C {
-    // omitting Header
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Background
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Header AND Background
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Background AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
     }
 }

--- a/Sources/Stack/TablerStackB.swift
+++ b/Sources/Stack/TablerStackB.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit, resultsBinding
 /// Stack-based table, with support for bound value types
 public struct TablerStackB<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable,
@@ -92,113 +93,4 @@ public struct TablerStackB<Element, Header, Row, RowBack, RowOver, Results>: Vie
             .background(rowBackground(element.wrappedValue))
             .overlay(rowOverlay(element.wrappedValue))
    }
-}
-
-public extension TablerStackB {
-    // omitting Header
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-
-    // omitting Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Binding<Results>)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-
-    // omitting Background
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Binding<Results>)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-    
-    // omitting Header AND Background
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-    
-    // omitting Background AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Binding<Results>)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         results: Binding<Results>)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
 }

--- a/Sources/Stack/TablerStackC.swift
+++ b/Sources/Stack/TablerStackC.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit
 /// Stack-based table, with support for reference types
 public struct TablerStackC<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable & ObservableObject,
@@ -80,114 +81,5 @@ public struct TablerStackC<Element, Header, Row, RowBack, RowOver, Results>: Vie
                 }
             }
         }
-    }
-}
-
-public extension TablerStackC {
-    // omitting Header
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-
-    // omitting Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-
-    // omitting Background
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-    
-    // omitting Header AND Background
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results)
-    }
-    
-    // omitting Background AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Results)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         results: Results)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results)
     }
 }

--- a/Sources/Stack/TablerStackM.swift
+++ b/Sources/Stack/TablerStackM.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit, selectBinding
 /// Stack-based table, with support for multi-select
 public struct TablerStackM<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable,
@@ -82,128 +83,5 @@ public struct TablerStackM<Element, Header, Row, RowBack, RowOver, Results>: Vie
                     .overlay(rowOverlay(element))
             }
         }
-    }
-}
-
-public extension TablerStackM {
-    // omitting Header
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Background
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header AND Background
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Background AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
     }
 }

--- a/Sources/Stack/TablerStackMB.swift
+++ b/Sources/Stack/TablerStackMB.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit, selectBinding, resultsBinding
 /// Stack-based table, with support for multi-select and bound value types
 public struct TablerStackMB<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable,
@@ -96,128 +97,5 @@ public struct TablerStackMB<Element, Header, Row, RowBack, RowOver, Results>: Vi
                                    selected: $selected))
             .background(rowBackground(element.wrappedValue))
             .overlay(rowOverlay(element.wrappedValue))
-    }
-}
-
-public extension TablerStackMB {
-    // omitting Header
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Background
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Header AND Background
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Background AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         results: Binding<Results>,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
     }
 }

--- a/Sources/Stack/TablerStackMC.swift
+++ b/Sources/Stack/TablerStackMC.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 
+// sourcery: AutoInit, selectBinding
 /// Stack-based table, with support for multi-select and reference types
 public struct TablerStackMC<Element, Header, Row, RowBack, RowOver, Results>: View
     where Element: Identifiable & ObservableObject,
@@ -85,128 +86,5 @@ public struct TablerStackMC<Element, Header, Row, RowBack, RowOver, Results>: Vi
                 }
             }
         }
-    }
-}
-
-public extension TablerStackMC {
-    // omitting Header
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Background
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowBackground: @escaping RowBackground,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: rowBackground,
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Header AND Background
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         @ViewBuilder rowOverlay: @escaping RowOverlay,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: rowOverlay,
-                  results: results,
-                  selected: selected)
-    }
-    
-    // omitting Background AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder header: @escaping HeaderContent,
-         @ViewBuilder row: @escaping RowContent,
-         results: Results,
-         selected: Binding<Selected>)
-        where RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: header,
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
-    }
-
-    // omitting Header, Background, AND Overlay
-    init(_ config: Config = .init(),
-         @ViewBuilder row: @escaping RowContent,
-         results: Results,
-         selected: Binding<Selected>)
-        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
-    {
-        self.init(config,
-                  header: { _ in EmptyView() },
-                  row: row,
-                  rowBackground: { _ in EmptyView() },
-                  rowOverlay: { _ in EmptyView() },
-                  results: results,
-                  selected: selected)
     }
 }

--- a/Templates/AutoInit.stencil
+++ b/Templates/AutoInit.stencil
@@ -1,0 +1,196 @@
+{% for type in types.structs %}
+{% if type|annotated:"AutoInit" %}
+// sourcery:file:{{ type.name }}+AutoInit
+
+import SwiftUI
+
+extension {{type.name}} {
+        // omitting Header
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        {% if type|annotated:"resultsBinding" %}
+        , results: Binding<Results>
+        {% else %}
+        , results: Results
+        {% endif %}
+        {% if type|annotated:"selectBinding" %}
+        , selected: Binding<Selected>
+        {% endif %}
+                  )
+        where Header == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: rowOverlay,
+                  results: results
+                  {% if type|annotated:"selectBinding" %}
+                  , selected: selected
+                  {% endif %})
+    }
+
+    // omitting Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        {% if type|annotated:"resultsBinding" %}
+        , results: Binding<Results>
+        {% else %}
+        , results: Results
+        {% endif %}
+        {% if type|annotated:"selectBinding" %}
+        , selected: Binding<Selected>
+        {% endif %}
+                  )
+        where RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  {% if type|annotated:"selectBinding" %}
+                  , selected: selected
+                  {% endif %})
+
+    }
+
+    // omitting Background
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        {% if type|annotated:"resultsBinding" %}
+        , results: Binding<Results>
+        {% else %}
+        , results: Results
+        {% endif %}
+        {% if type|annotated:"selectBinding" %}
+        , selected: Binding<Selected>
+        {% endif %}
+                  )
+        where RowBack == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  {% if type|annotated:"selectBinding" %}
+                  , selected: selected
+                  {% endif %})
+    }
+
+    // omitting Header AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowBackground: @escaping RowBackground
+        {% if type|annotated:"resultsBinding" %}
+        , results: Binding<Results>
+        {% else %}
+        , results: Results
+        {% endif %}
+        {% if type|annotated:"selectBinding" %}
+        , selected: Binding<Selected>
+        {% endif %}
+                  )
+        where Header == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: rowBackground,
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  {% if type|annotated:"selectBinding" %}
+                  , selected: selected
+                  {% endif %})
+    }
+
+    // omitting Header AND Background
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent,
+         @ViewBuilder rowOverlay: @escaping RowOverlay
+        {% if type|annotated:"resultsBinding" %}
+        , results: Binding<Results>
+        {% else %}
+        , results: Results
+        {% endif %}
+        {% if type|annotated:"selectBinding" %}
+        , selected: Binding<Selected>
+        {% endif %}
+                  )
+        where Header == EmptyView, RowBack == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: rowOverlay,
+                  results: results
+                  {% if type|annotated:"selectBinding" %}
+                  , selected: selected
+                  {% endif %})
+    }
+
+    // omitting Background AND Overlay
+    init(_ config: Config,
+         @ViewBuilder header: @escaping HeaderContent,
+         @ViewBuilder row: @escaping RowContent
+        {% if type|annotated:"resultsBinding" %}
+        , results: Binding<Results>
+        {% else %}
+        , results: Results
+        {% endif %}
+        {% if type|annotated:"selectBinding" %}
+        , selected: Binding<Selected>
+        {% endif %}
+                  )
+        where RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: header,
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  {% if type|annotated:"selectBinding" %}
+                  , selected: selected
+                  {% endif %})
+    }
+
+    // omitting Header, Background, AND Overlay
+    init(_ config: Config,
+         @ViewBuilder row: @escaping RowContent
+        {% if type|annotated:"resultsBinding" %}
+        , results: Binding<Results>
+        {% else %}
+        , results: Results
+        {% endif %}
+        {% if type|annotated:"selectBinding" %}
+        , selected: Binding<Selected>
+        {% endif %}
+                  )
+
+        where Header == EmptyView, RowBack == EmptyView, RowOver == EmptyView
+    {
+        self.init(config,
+                  header: { _ in EmptyView() },
+                  row: row,
+                  rowBackground: { _ in EmptyView() },
+                  rowOverlay: { _ in EmptyView() },
+                  results: results
+                  {% if type|annotated:"selectBinding" %}
+                  , selected: selected
+                  {% endif %})
+    }
+}
+// sourcery:end
+{% endif %}
+{% endfor %}

--- a/Templates/AutoInit.stencil
+++ b/Templates/AutoInit.stencil
@@ -5,7 +5,7 @@
 import SwiftUI
 
 extension {{type.name}} {
-        // omitting Header
+    // omitting Header
     init(_ config: Config,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,

--- a/Templates/AutoInit.stencil
+++ b/Templates/AutoInit.stencil
@@ -4,9 +4,9 @@
 
 import SwiftUI
 
-extension {{type.name}} {
+public extension {{type.name}} {
     // omitting Header
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -33,7 +33,7 @@ extension {{type.name}} {
     }
 
     // omitting Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
@@ -61,7 +61,7 @@ extension {{type.name}} {
     }
 
     // omitting Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
@@ -88,7 +88,7 @@ extension {{type.name}} {
     }
 
     // omitting Header AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowBackground: @escaping RowBackground
         {% if type|annotated:"resultsBinding" %}
@@ -114,7 +114,7 @@ extension {{type.name}} {
     }
 
     // omitting Header AND Background
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent,
          @ViewBuilder rowOverlay: @escaping RowOverlay
         {% if type|annotated:"resultsBinding" %}
@@ -140,7 +140,7 @@ extension {{type.name}} {
     }
 
     // omitting Background AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder header: @escaping HeaderContent,
          @ViewBuilder row: @escaping RowContent
         {% if type|annotated:"resultsBinding" %}
@@ -166,7 +166,7 @@ extension {{type.name}} {
     }
 
     // omitting Header, Background, AND Overlay
-    init(_ config: Config,
+    init(_ config: Config = .init(),
          @ViewBuilder row: @escaping RowContent
         {% if type|annotated:"resultsBinding" %}
         , results: Binding<Results>


### PR DESCRIPTION
Most init() functions for the table variants were manually generated, resulting in needless complexity.

Now they're generated using Sourcery with the AutoInit.stencil template.

This is a step towards adding footer support.